### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "example": "node example.js"
   },
   "author": "freeman-lab",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freeman-lab/pdf-to-png.git"
+  },
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
This will allow people to find [the GitHub repository](https://github.com/freeman-lab/pdf-to-png) from [the npmjs page](https://www.npmjs.com/package/pdf-to-png)